### PR TITLE
Remote room refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "devDependencies": {
         "@types/lodash": "^3.10.2",
         "@types/node": "^10.17.30",
+        "@types/screeps": "^3.2.0",
         "lodash": "^4.17.11",
         "prettier": "^1.18.2",
         "rollup": "^0.63.5",
@@ -46,8 +47,7 @@
         "tslint-config-prettier": "^1.18.0",
         "tslint-plugin-prettier": "^1.3.0",
         "typedoc": "^0.15.5",
-        "typescript": "^3.7.5",
-        "@types/screeps": "^3.2.0"
+        "typescript": "^3.7.5"
     },
     "dependencies": {
         "npm": "^6.13.6",

--- a/src/Empire/Empire.Api.ts
+++ b/src/Empire/Empire.Api.ts
@@ -36,17 +36,23 @@ export class EmpireApi {
 
         for (const flag of newFlags) {
             // Find the proper implementation of the flag processer we need
+            let processedFlag = false;
             for (const i in PROCESS_FLAG_HELPERS) {
                 const currentHelper: IFlagProcesser = PROCESS_FLAG_HELPERS[i];
                 if (currentHelper.primaryColor === flag.color) {
                     // We've found primary color, search for undefined or matching secondary color
                     currentHelper.processFlag(flag);
+                    processedFlag = true;
                     break;
                 }
+            }
+
+            if (!processedFlag) {
                 // If we make it here, we didn't find a match for the flag type, delete the flag and carry on
                 MemoryApi_Empire.createEmpireAlertNode("Attempted to process flag of an unhandled type.", 10);
                 flag.memory.processed = true;
                 flag.memory.complete = true;
+                return;
             }
 
             // Create room memory for the dependent room to prevent errors in accessing the rooms memory for spawning and traveling

--- a/src/Empire/Empire.Api.ts
+++ b/src/Empire/Empire.Api.ts
@@ -40,10 +40,8 @@ export class EmpireApi {
                 const currentHelper: IFlagProcesser = PROCESS_FLAG_HELPERS[i];
                 if (currentHelper.primaryColor === flag.color) {
                     // We've found primary color, search for undefined or matching secondary color
-                    if (!currentHelper.secondaryColor || currentHelper.secondaryColor === flag.secondaryColor) {
-                        currentHelper.processFlag(flag);
-                        break;
-                    }
+                    currentHelper.processFlag(flag);
+                    break;
                 }
                 // If we make it here, we didn't find a match for the flag type, delete the flag and carry on
                 MemoryApi_Empire.createEmpireAlertNode("Attempted to process flag of an unhandled type.", 10);
@@ -172,11 +170,20 @@ export class EmpireApi {
         Memory.flags[flag.name].flagType = flagTypeConst;
         Memory.flags[flag.name].flagName = flag.name;
 
+        // Delete all creep associated with remote room
         const ownedRooms: Room[] = MemoryApi_Empire.getOwnedRooms();
         delete Memory.rooms[remoteRoomName];
         for (const room of ownedRooms) {
             if (!room.memory.remoteRooms) room.memory.remoteRooms = {};
             delete Memory.rooms[room.name].remoteRooms![remoteRoomName];
+        }
+
+        // Suicide all creeps associated with the remote room
+        for (let i in Game.creeps) {
+            const creep: Creep = Game.creeps[i];
+            if (creep.memory.targetRoom === remoteRoomName) {
+                creep.suicide();
+            }
         }
     }
 }

--- a/src/Empire/Empire.Api.ts
+++ b/src/Empire/Empire.Api.ts
@@ -77,14 +77,11 @@ export class EmpireApi {
     /**
      * look for dead flags (memory with no associated flag existing) and remove them
      */
-    public static cleanDeadFlags(): void {
+    public static cleanClaimRooms(): void {
         // Get all flag based action memory structures (Remote, Claim, and Attack Room Memory)
         const allRooms = MemoryApi_Empire.getOwnedRooms();
         const claimRooms: Array<ClaimRoomMemory | undefined> = _.flatten(
             _.map(allRooms, room => MemoryApi_Room.getClaimRooms(room))
-        );
-        const remoteRooms: Array<RemoteRoomMemory | undefined> = _.flatten(
-            _.map(allRooms, room => MemoryApi_Room.getRemoteRooms(room))
         );
 
         // Remove claim room flags once the room is sufficiently built up
@@ -92,11 +89,9 @@ export class EmpireApi {
 
         // Clean dead flags from memory structures
         EmpireHelper.cleanDeadClaimRoomFlags(claimRooms);
-        EmpireHelper.cleanDeadRemoteRoomsFlags(remoteRooms);
 
         // Clean the memory of each type of dependent room memory structure with no existing flags associated
         EmpireHelper.cleanDeadClaimRooms(claimRooms);
-        EmpireHelper.cleanDeadRemoteRooms(remoteRooms);
     }
 
     /**

--- a/src/Empire/EmpireHelper.ts
+++ b/src/Empire/EmpireHelper.ts
@@ -101,8 +101,8 @@ export class EmpireHelper {
             throw new UserException(
                 "Manual Dependent Room Finding Error",
                 "Flag [" +
-                    overrideFlag.name +
-                    "]. We have no vision in the room you attempted to manually set as override dependent room.",
+                overrideFlag.name +
+                "]. We have no vision in the room you attempted to manually set as override dependent room.",
                 ERROR_ERROR
             );
         }
@@ -240,70 +240,6 @@ export class EmpireHelper {
                         10
                     );
                     delete claimRoom!.flags[flag];
-                }
-            }
-        }
-    }
-
-    /**
-     * if an remote room has no flags associated with it, delete the attack room memory structure
-     * @param attackRooms an array of all the attack room memory structures in the empire
-     */
-    public static cleanDeadRemoteRooms(remoteRooms: Array<RemoteRoomMemory | undefined>): void {
-        // Loop over remote rooms, and if we find one with no associated flag, remove it
-        for (const remoteRoom in remoteRooms) {
-            if (!remoteRooms[remoteRoom]) {
-                continue;
-            }
-            const remoteRoomName: string = remoteRooms[remoteRoom]!.roomName;
-
-            if (!remoteRooms[remoteRoom]!.flags[0]) {
-                MemoryApi_Empire.createEmpireAlertNode(
-                    "Removing Remote Room [" + remoteRooms[remoteRoom]!.roomName + "]",
-                    10
-                );
-
-                // Get the dependent room for this room
-                const dependentRoom: Room | undefined = _.find(MemoryApi_Empire.getOwnedRooms(), (room: Room) => {
-                    const rr = room.memory.remoteRooms;
-                    return _.some(rr!, (innerRR: RemoteRoomMemory) => {
-                        if (innerRR) {
-                            return innerRR.roomName === remoteRoomName;
-                        }
-                        return false;
-                    });
-                });
-
-                delete Memory.rooms[dependentRoom!.name].remoteRooms![remoteRoom];
-            }
-        }
-    }
-
-    /**
-     * removes all claim room memory structures that do not have an existing flag associated with them
-     * @param claimRooms an array of all the claim room memory structures in the empire
-     */
-    public static cleanDeadRemoteRoomsFlags(remoteRooms: Array<RemoteRoomMemory | undefined>): void {
-        // Loop over remote rooms and make sure the flag they're referencing actually exists
-        // Delete the memory structure if its not associated with an existing flag
-        for (const remoteRoom of remoteRooms) {
-            if (!remoteRoom) {
-                continue;
-            }
-
-            for (const flag in remoteRoom!.flags) {
-                if (!remoteRoom!.flags[flag]) {
-                    continue;
-                }
-
-                // Tell typescript that these are claim flag memory structures
-                const currentFlag: RemoteFlagMemory = remoteRoom!.flags[flag] as RemoteFlagMemory;
-                if (!Game.flags[currentFlag.flagName]) {
-                    MemoryApi_Empire.createEmpireAlertNode(
-                        "Removing [" + flag + "] from Remote Room Memory [" + remoteRoom!.roomName + "]",
-                        10
-                    );
-                    delete remoteRoom!.flags[flag];
                 }
             }
         }

--- a/src/Empire/EmpireManager.ts
+++ b/src/Empire/EmpireManager.ts
@@ -17,6 +17,6 @@ export class EmpireManager {
 
         // Delete unused flags and flag memory
         EmpireApi.deleteCompleteFlags();
-        EmpireApi.cleanDeadFlags();
+        EmpireApi.cleanClaimRooms();
     }
 }

--- a/src/Empire/ProcessFlagHelpers/ProcessDefaultRemoteRoom.ts
+++ b/src/Empire/ProcessFlagHelpers/ProcessDefaultRemoteRoom.ts
@@ -1,4 +1,4 @@
-import { UserException, EmpireHelper, MemoryApi_Room, MemoryApi_Empire, EmpireApi } from "Utils/Imports/internals";
+import { UserException, EmpireHelper, MemoryApi_Room, MemoryApi_Empire, EmpireApi, REMOTE_ENERGY } from "Utils/Imports/internals";
 import _ from "lodash";
 
 export class ProcessDefaultRemoteRoom implements IFlagProcesser {
@@ -15,70 +15,16 @@ export class ProcessDefaultRemoteRoom implements IFlagProcesser {
      * @param flag
      */
     public processFlag(flag: Flag): void {
-        // Get the host room and set the flags memory
-        const dependentRoom: Room = Game.rooms[EmpireHelper.findDependentRoom(flag.pos.roomName)];
-        const flagTypeConst: FlagTypeConstant | undefined = EmpireHelper.getFlagType(flag);
-        const roomName: string = flag.pos.roomName;
-        Memory.flags[flag.name].complete = false;
-        Memory.flags[flag.name].processed = true;
-        Memory.flags[flag.name].timePlaced = Game.time;
-        Memory.flags[flag.name].flagType = flagTypeConst;
-        Memory.flags[flag.name].flagName = flag.name;
-
         switch (flag.secondaryColor) {
             // Create an energy focused remote room
             case COLOR_YELLOW:
-                EmpireApi.createRemoteRoomInstance(roomName);
+                EmpireApi.createRemoteRoomInstance(flag, REMOTE_ENERGY);
                 break;
 
             // Clear an existing remote room
             case COLOR_RED:
-                EmpireApi.removeRemoteRoom(roomName);
+                EmpireApi.removeRemoteRoomInstance(flag);
                 break;
         }
-
-        // Create the RemoteFlagMemory object for this flag
-        const remoteFlagMemory: RemoteFlagMemory = {
-            flagName: flag.name,
-            flagType: flagTypeConst
-        };
-
-        // If the dependent room already has this room covered, set the flag to be deleted and throw a warning
-        const existingDepedentRemoteRoomMem: RemoteRoomMemory | undefined = _.find(
-            MemoryApi_Room.getRemoteRooms(dependentRoom),
-            (rr: RemoteRoomMemory) => {
-                if (rr) {
-                    return rr.roomName === roomName;
-                }
-                return false;
-            }
-        );
-
-        if (existingDepedentRemoteRoomMem) {
-            Memory.flags[flag.name].complete = true;
-            throw new UserException(
-                "Already working this dependent room!",
-                "The room you placed the remote flag in is already being worked by " +
-                existingDepedentRemoteRoomMem.roomName,
-                ERROR_WARN
-            );
-        }
-
-        // Otherwise, add a brand new memory structure onto it
-        const remoteRoomMemory: RemoteRoomMemory = {
-            sources: { cache: Game.time, data: 1 },
-            hostiles: { cache: Game.time, data: null },
-            structures: { cache: Game.time, data: null },
-            roomName: flag.pos.roomName,
-            flags: [remoteFlagMemory],
-            reserveTTL: 0,
-            reserveUsername: undefined
-        };
-
-        MemoryApi_Empire.createEmpireAlertNode(
-            "Remote Flag [" + flag.name + "] processed. Host Room: [" + dependentRoom.name + "]",
-            10
-        );
-        dependentRoom.memory.remoteRooms!.push(remoteRoomMemory);
     }
 }

--- a/src/Empire/ProcessFlagHelpers/ProcessDefaultRemoteRoom.ts
+++ b/src/Empire/ProcessFlagHelpers/ProcessDefaultRemoteRoom.ts
@@ -3,7 +3,6 @@ import _ from "lodash";
 
 export class ProcessDefaultRemoteRoom implements IFlagProcesser {
     public primaryColor: ColorConstant = COLOR_YELLOW;
-    public secondaryColor: ColorConstant = COLOR_YELLOW;
 
     constructor() {
         const self = this;

--- a/src/Empire/ProcessFlagHelpers/ProcessDefaultRemoteRoom.ts
+++ b/src/Empire/ProcessFlagHelpers/ProcessDefaultRemoteRoom.ts
@@ -1,4 +1,4 @@
-import { UserException, EmpireHelper, MemoryApi_Room, MemoryApi_Empire } from "Utils/Imports/internals";
+import { UserException, EmpireHelper, MemoryApi_Room, MemoryApi_Empire, EmpireApi } from "Utils/Imports/internals";
 import _ from "lodash";
 
 export class ProcessDefaultRemoteRoom implements IFlagProcesser {
@@ -24,6 +24,18 @@ export class ProcessDefaultRemoteRoom implements IFlagProcesser {
         Memory.flags[flag.name].timePlaced = Game.time;
         Memory.flags[flag.name].flagType = flagTypeConst;
         Memory.flags[flag.name].flagName = flag.name;
+
+        switch (flag.secondaryColor) {
+            // Create an energy focused remote room
+            case COLOR_YELLOW:
+                EmpireApi.createRemoteRoomInstance(roomName);
+                break;
+
+            // Clear an existing remote room
+            case COLOR_RED:
+                EmpireApi.removeRemoteRoom(roomName);
+                break;
+        }
 
         // Create the RemoteFlagMemory object for this flag
         const remoteFlagMemory: RemoteFlagMemory = {

--- a/src/Jobs/ClaimPartJobs.ts
+++ b/src/Jobs/ClaimPartJobs.ts
@@ -165,7 +165,7 @@ export class ClaimPartJobs implements IJobTypeHelper {
     public static createReserveJobs(room: Room): ClaimPartJob[] {
         // Consider the room if we are under our reserve threshold, or if it belongs to someone not on the ally list
         const reserveRooms: RemoteRoomMemory[] = MemoryApi_Room.getRemoteRooms(room, (roomMemory: RemoteRoomMemory) => {
-            if (!roomMemory.reserveUsername) return false;
+            if (!roomMemory.reserveUsername) return true;
             return ((roomMemory.reserveTTL < RESERVER_MIN_TTL) || !ALLY_LIST.includes(roomMemory.reserveUsername));
         });
 

--- a/src/Market/MarketManager.ts
+++ b/src/Market/MarketManager.ts
@@ -15,15 +15,15 @@ export class MarketManager {
             return;
         }
 
-        console.log(
-            bestOrder.resourceType,
-            bestOrder.amount,
-            bestOrder.price,
-            bestOrder.roomName,
-            Game.market.calcTransactionCost(bestOrder.amount, bestOrder.roomName!, "W9N7")
-        );
+        // console.log(
+        //     bestOrder.resourceType,
+        //     bestOrder.amount,
+        //     bestOrder.price,
+        //     bestOrder.roomName,
+        //     Game.market.calcTransactionCost(bestOrder.amount, bestOrder.roomName!, "W9N7")
+        // );
 
         // Code to put in console to deal this order
-        console.log(`Game.market.deal("${bestOrder.id}", ${bestOrder.amount}, "W9N7")`);
+        // console.log(`Game.market.deal("${bestOrder.id}", ${bestOrder.amount}, "W9N7")`);
     }
 }

--- a/src/Memory/Memory.Room.Api.ts
+++ b/src/Memory/Memory.Room.Api.ts
@@ -646,6 +646,10 @@ export class MemoryApi_Room {
         }
 
         let remoteRooms: RemoteRoomMemory[] = [];
+        for (let i in room.memory.remoteRooms) {
+            const rr: RemoteRoomMemory = room.memory.remoteRooms[i];
+            if (rr) remoteRooms.push(rr);
+        }
 
         // TargetRoom parameter provided
         if (targetRoom !== undefined) {

--- a/src/Memory/Memory.Room.Api.ts
+++ b/src/Memory/Memory.Room.Api.ts
@@ -58,9 +58,9 @@ export class MemoryApi_Room {
             throw new UserException(
                 "Tried to getUpgraderLink of a room with no controller",
                 "Get Upgrader Link was called for room [" +
-                    room.name +
-                    "]" +
-                    ", but theres no controller in this room.",
+                room.name +
+                "]" +
+                ", but theres no controller in this room.",
                 ERROR_WARN
             );
         }
@@ -79,34 +79,6 @@ export class MemoryApi_Room {
      */
     public static updateUpgraderLink(room: Room, id: string): void {
         room.memory.upgradeLink = id;
-    }
-
-    /**
-     * Go through the room's depedent room memory and remove null values
-     * @param room the room we are cleaning the memory structure for
-     */
-    public static cleanDependentRoomMemory(room: Room): void {
-        // Re-map Remote Room array to remove null values
-        const allRemoteRooms: RemoteRoomMemory[] = Memory.rooms[room.name].remoteRooms!;
-        const nonNullRemoteRooms: RemoteRoomMemory[] = [];
-
-        _.forEach(allRemoteRooms, (rr: RemoteRoomMemory) => {
-            if (rr !== null) {
-                nonNullRemoteRooms.push(rr);
-            }
-        });
-        Memory.rooms[room.name].remoteRooms = nonNullRemoteRooms;
-
-        // Re-map Remote Room array to remove null values
-        const allClaimRooms: ClaimRoomMemory[] = Memory.rooms[room.name].claimRooms!;
-        const nonNullClaimRooms: ClaimRoomMemory[] = [];
-
-        _.forEach(allClaimRooms, (rr: ClaimRoomMemory) => {
-            if (rr !== null) {
-                nonNullClaimRooms.push(rr);
-            }
-        });
-        Memory.rooms[room.name].claimRooms = nonNullClaimRooms;
     }
 
     /**
@@ -157,7 +129,7 @@ export class MemoryApi_Room {
                 defcon: -1,
                 shotLastTick: false,
                 hostiles: { data: null, cache: null },
-                remoteRooms: [],
+                remoteRooms: {},
                 roomState: ROOM_STATE_INTRO,
                 sources: { data: null, cache: null },
                 minerals: { data: null, cache: null },
@@ -673,7 +645,7 @@ export class MemoryApi_Room {
             return [];
         }
 
-        let remoteRooms: RemoteRoomMemory[] = Memory.rooms[room.name].remoteRooms!;
+        let remoteRooms: RemoteRoomMemory[] = [];
 
         // TargetRoom parameter provided
         if (targetRoom !== undefined) {

--- a/src/Memory/MemoryManagement.ts
+++ b/src/Memory/MemoryManagement.ts
@@ -19,7 +19,6 @@ export class MemoryManager {
         _.forEach(ownedRooms, (room: Room) => {
             const isOwnedRoom: boolean = true;
             MemoryApi_Room.initRoomMemory(room.name, isOwnedRoom);
-            MemoryApi_Room.cleanDependentRoomMemory(room);
         });
 
         const dependentRooms: Room[] = MemoryApi_Room.getVisibleDependentRooms();

--- a/src/Room/Room.State.Helper.ts
+++ b/src/Room/Room.State.Helper.ts
@@ -203,7 +203,7 @@ export class RoomHelper_State {
      */
     public static numRemoteSources(room: Room): number {
         // TODO: remove sources and structures from the remote room dependent memory itself
-        const remoteRooms: RemoteRoomMemory[] = Memory.rooms[room.name].remoteRooms!;
+        const remoteRooms: RemoteRoomObject = Memory.rooms[room.name].remoteRooms!;
         let numSources: number = 0;
 
         _.forEach(remoteRooms, (rr: RemoteRoomMemory) => {

--- a/src/Room/Room.State.Helper.ts
+++ b/src/Room/Room.State.Helper.ts
@@ -5,7 +5,8 @@ import {
     MemoryApi_Room,
     MemoryApi_Creep,
     MemoryApi_Empire,
-    ALLY_LIST
+    ALLY_LIST,
+    ConsoleCommands
 } from "Utils/Imports/internals";
 import _ from "lodash";
 
@@ -210,6 +211,7 @@ export class RoomHelper_State {
             if (!rr) {
                 return;
             }
+
             // Don't consider these sources valid if the controller is reserved by an enemy, or theres defcon 2 >=
             if (
                 SpawnHelper.isRemoteRoomEnemyReserved(rr) ||
@@ -226,6 +228,7 @@ export class RoomHelper_State {
             }
             numSources += sourcesInRoom;
         });
+
         return numSources;
     }
 

--- a/src/Utils/Imports/constants.ts
+++ b/src/Utils/Imports/constants.ts
@@ -44,6 +44,11 @@ export const TOWER_DRAINER_MAN = "towerDrainerSquad";
 export const DOMESTIC_DEFENDER_MAN = "domesticDefenderSquad";
 export const REMOTE_DEFENDER_MAN = "remoteDefenderSquad";
 
+// Remote Room Type Constants
+export const REMOTE_ENERGY = "remoteRoomEnergy";
+export const REMOTE_SK_ENERGY = "remoteRoomSKEnergy";
+export const REMOTE_SK_COMBINED = "remoteRoomSKCombined";
+
 // Operation Strategy Constants
 export const OP_STRATEGY_NONE = "none";
 export const OP_STRATEGY_FFA = "ffa";

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -431,7 +431,6 @@ interface IJobTypeHelper {
  */
 interface IFlagProcesser {
     primaryColor: ColorConstant;
-    secondaryColor: ColorConstant | undefined;
     processFlag: (flag: Flag) => void;
 }
 // --------------------------------------------------------------------

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1420,6 +1420,10 @@ interface RemoteRoomMemory extends DependentRoomParentMemory {
      * username reserving the controller - used to detect invader reserve
      */
     reserveUsername: string | undefined;
+    /**
+     * The type of remote room this is
+     */
+    remoteRoomType: RemoteRoomTypeConstant;
 }
 
 /**
@@ -1543,3 +1547,15 @@ interface ETAMemory {
 type AllCreepCount = {
     [key in RoleConstant]: number;
 };
+
+/**
+ * Constants for types of remote rooms
+ */
+type REMOTE_ENERGY = "remoteRoomEnergy";
+type REMOTE_SK_ENERGY = "remoteRoomSKEnergy";
+type REMOTE_SK_COMBINED = "remoteRoomSKCombined";
+
+type RemoteRoomTypeConstant =
+    REMOTE_ENERGY
+    | REMOTE_SK_COMBINED
+    | REMOTE_SK_ENERGY;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1006,7 +1006,7 @@ interface RoomMemory {
     /**
      * Names of all rooms flagged to remote harvest
      */
-    remoteRooms?: RemoteRoomMemory[];
+    remoteRooms?: RemoteRoomObject;
     /**
      * Names of all rooms flagged to colonize
      */
@@ -1023,6 +1023,10 @@ interface RoomMemory {
      * The last tick we had a scout spawn
      */
     lastScoutSpawn?: number;
+}
+
+interface RemoteRoomObject {
+    [key: string]: RemoteRoomMemory;
 }
 
 interface Memory {


### PR DESCRIPTION
This abstracts remote rooms into an instance creation for future automation and to match attack flags. This also added the removal flag (yellow + red) and improved removal of remote rooms. 

Fixed bug with remote reservers not getting a job (now they're taking our jobs!!!)